### PR TITLE
Add APIM SKU parameter and adjust policies based on SKU type

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -14,6 +14,14 @@ param location string
 @description('Id of the user or app to assign application roles')
 param principalId string
 
+@description('The SKU of the APIM instance')
+@allowed([
+  'Developer'
+  'Consumption'
+  'Standard'
+])
+param apimSku string
+
 // Tags that should be applied to all resources.
 // 
 // Note that 'azd-service-name' tags should be applied separately to service host resources.
@@ -52,6 +60,7 @@ module apim 'apimdeploy.bicep' = {
     name: !empty(apimServiceName) ? apimServiceName : '${abbrs.apiManagementService}${resourceToken}'
     location: location
     tags: tags
+    apimSku: apimSku
     WebAppURL: conferenceAPI.outputs.WebAppURL
   }
 


### PR DESCRIPTION
This update can deploy Standard, Developer, or Consumption SKUs for APIM. While normally, it deploys with the header removal policy and the rate limiting policy on the GetSpeakers operation, the Consumption does not support that policy, so the Consumption plan is deployed without rate limiting. 